### PR TITLE
腾讯日线修正

### DIFF
--- a/Ashare.py
+++ b/Ashare.py
@@ -9,6 +9,7 @@ def get_price_day_tx(code, end_date='', count=10, frequency='1d'):     #日线�
     URL=f'http://web.ifzq.gtimg.cn/appstock/app/fqkline/get?param={code},{unit},,{end_date},{count},qfq'     
     st= json.loads(requests.get(URL).content);    ms='qfq'+unit;      stk=st['data'][code]   
     buf=stk[ms] if ms in stk else stk[unit]       #指数返回不是qfqday,是day
+    buf = [item[:6] for item in buf] # 去掉第七行cqr数据(例如hk00002)
     df=pd.DataFrame(buf,columns=['time','open','close','high','low','volume'],dtype='float')     
     df.time=pd.to_datetime(df.time);    df.set_index(['time'], inplace=True);   df.index.name=''          #处理索引 
     return df


### PR DESCRIPTION
腾讯日线有时候返回7行数据：例如 hk00002
["2021-09-02", "77.600", "77.900", "77.900", "77.200", "1748621.000", {
					"cqr": "2021-09-02",
					"FHcontent": "\u7b2c\u4e8c\u6b21\u4e2d\u671f\u606f0.63\u6e2f\u5143;",
					"HGcontent": "",
					"paixiri": "2021-09-15",
					"hgcgContent": "",
					"ggContent": ""
				}],


![image](https://user-images.githubusercontent.com/9114492/153153217-5abbf545-ab85-4874-ac2c-7e962d182604.png)

